### PR TITLE
Issue on Linux with '/dev/stdin' "can't open".

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,7 +86,6 @@
     if (options.version) {
       args.push('--version');
     }
-    args.push('/dev/stdin');
     return through.obj(function(file, encoding, callback) {
       var b, cd, ext, program, stdin, str;
       if (file.isNull()) {
@@ -99,6 +98,7 @@
       }
       cd = path.dirname(file.path);
       ext = options.ext ? options.ext : '.txt';
+      args.push(file.path);
       file.path = gutil.replaceExtension(file.path, ext);
       program = spawn(cmnd, args);
       b = new Buffer(0);


### PR DESCRIPTION
There is an issue on Linux where the /dev/stdin is not readable and PhantomJS then returns the response:

Can't open '/dev/stdin'

To fix this you need to pass PhantomJS to the filename instead of the stdin and this change does just that. I've tested this on Mac OS X and Linux and it worked fine.